### PR TITLE
Address failing specs

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -16,8 +16,9 @@ class ItemsController < ApplicationController
   def update
     merchant = Merchant.find(params[:merchant_id])
     item = Item.find(params[:id])
+
     if item.update(item_params)
-      if params[:status]
+      if item_params[:status]
         item.save
         redirect_to "/merchants/#{merchant.id}/items"
       else

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -1,4 +1,4 @@
-<%= form_with url: "/merchants/#{@merchant.id}/items/#{@item.id}", method: :patch, local: true do |form| %>
+<%= form_with model: @item, url: "/merchants/#{@merchant.id}/items/#{@item.id}", method: :patch, local: true do |form| %>
   <%= form.label :name %>
   <%= form.text_field :name, :value => "#{@item.name}" %>
   <%= form.label :description %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -2,21 +2,14 @@
 
 <h4><%= link_to "Create a new item", "/merchants/#{@merchant.id}/items/new" %></h4>
 
-<% @merchant.items.each do |item| %>
-  <p>Name: <%=link_to "#{item.name}", "/merchants/#{@merchant.id}/items/#{item.id}" %>
-    <p>Description: <%= item.description %></p>
-    <p>Description: <%= item.description %></p>
-    <p>Status: <%= item.status %></p>
-    <%= button_to 'Enable',  "merchants/#{@merchant.id}/items", method: :patch %> |
-    <%= button_to 'Disable', "merchants/#{@merchant.id}/items", method: :patch %></p>
-<% end %>
-
 <h3>Enabled Items</h3>
 <% @merchant.items.each do |item| %>
   <% if item.status == 'enabled' %>
     <div id='enabled_item_<%= item.id %>'>
       <p><%=link_to "#{item.name}", "/merchants/#{@merchant.id}/items/#{item.id}" %>
-      <%= button_to 'Disable', "/merchants/#{@merchant.id}/items/#{item.id}?status=disabled", id: "#{item.id}", method: :patch %></p>
+      <p>Description: <%= item.description %></p>
+      <p>Status: <%= item.status %></p>
+      <%= button_to 'Disable', "/merchants/#{@merchant.id}/items/#{item.id}", id: "#{item.id}", method: :patch, params: {"item[status]" => "disabled"} %></p>
     </div>
   <% end %>
 <% end %>
@@ -26,7 +19,9 @@
   <% if item.status == 'disabled' %>
     <div id='disabled_item_<%= item.id %>'>
       <p><%=link_to "#{item.name}", "/merchants/#{@merchant.id}/items/#{item.id}" %>
-      <%= button_to 'Enable',  "/merchants/#{@merchant.id}/items/#{item.id}?status=enabled", id: "#{item.id}", method: :patch %></p> 
+      <p>Description: <%= item.description %></p>
+      <p>Status: <%= item.status %></p>
+      <%= button_to 'Enable',  "/merchants/#{@merchant.id}/items/#{item.id}", id: "#{item.id}", method: :patch, params: {"item[status]" => "enabled"} %></p> 
     </div>
   <% end %>
 <% end %>

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe 'Merchant Items Index page' do
       expect(page).to have_link("#{@item_1.name}", :href => "/merchants/#{@merchant_1.id}/items/#{@item_1.id}")
       expect(page).to have_link("#{@item_2.name}", :href => "/merchants/#{@merchant_1.id}/items/#{@item_2.id}")
       expect(page).to_not have_link("#{@item_8.name}", :href => "/merchants/#{@merchant_2.id}/items/#{@item_8.id}")
-       
+
       click_link("#{@item_1.name}")
       
       expect(current_path).to eq("/merchants/#{@merchant_1.id}/items/#{@item_1.id}")


### PR DESCRIPTION
- Adds the model to `form_with` in an item's `edit.html.erb`
- Removes params from URL and places them explicitly behind an `item` key for disabling and enabling merchant items to adhere to strong params
- All specs passing